### PR TITLE
Only template kickstart files for non-empty groups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,4 +68,6 @@
 - name: create_kickstart_group_files
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"
   with_items: "{{ groups }}"
-  when: hostvars[groups[item][0]]['os_disks'] is defined
+  when:
+    - groups[item][0] is defined
+    - hostvars[groups[item][0]]['os_disks'] is defined


### PR DESCRIPTION
This task now also skips in case there is an empty group