### PR TITLE
by default do not install chrony during kickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ Caveats
 
 The role doesn't allow much in the way of kickstart parametrization. It might
 make some assumptions on the system state (e.g DHCP config).
+
+The role by default does not install chrony in the kickstart, set variable
+
+<pre>
+dhcp_kickstart_install_chrony: True
+</pre>
+
+to keep chrony.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
+dhcp_kickstart_install_chrony: False

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -41,6 +41,9 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -NetworkManager-glib
 -NetworkManager-team
 -NetworkManager-wwan
+{% if dhcp_kickstart_install_chrony == false %}
+-chrony
+{% endif %}
 %end
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1


### PR DESCRIPTION
disable by setting this ansible variable:

dhcp_kickstart_do_not_install_chrony: False