### PR TITLE
Testing: actually run the playbook & install policycoreutils (for restorecon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Mandatory:
 Optional:
  - extra_kernel_params (for the kickstart)
  - dhcp_domain
+ - memtest86_0_path (for pointing to a memtest.0 PXE NBP)
 
 The nodes which only need to be set up for DHCP need to be in the
 (by default) "dhcp_only_nodes"  group. These nodes need the following 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,3 +82,6 @@
   when:
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
+
+- name: copy memtest.0 PXE NBP
+  copy: src=memtest.0 dest=/var/www/memtest.0 owner=apache group=apache mode="0440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,4 +84,4 @@
     - hostvars[groups[item][0]]['os_disks'] is defined
 
 - name: copy memtest.0 PXE NBP
-  copy: src=memtest.0 dest=/var/www/memtest.0 owner=apache group=apache mode="0440"
+  copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,11 @@
   when: groups[dhcp_pxe_group] is defined
   notify:
     - restart dhcpd
+    
+- name: install restorecon for selinux
+  package:
+    name: policycoreutils
+    state: installed
 
 - name: ipxe_selinux_context
   command: restorecon -Rv /var/lib/tftpboot/

--- a/templates/pxe_node.conf
+++ b/templates/pxe_node.conf
@@ -3,3 +3,6 @@ kernel_url_path={{ hostvars[item]['kernel_url_path'] }}
 {% if 'extra_kernel_params' in hostvars[item] %}
 extra_kernel_params={{ hostvars[item]['extra_kernel_params'] }}
 {% endif %}
+{% if 'memtest86_0_path' in hostvars[item] %}
+memtest86_0_path={{ hostvars[item]['memtest86_0_path'] }}
+{% endif %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -132,7 +132,7 @@ function main(){
 #    test_install_requirements
     test_ansible_setup
     test_playbook_syntax
-#    test_playbook
+    test_playbook
 #    test_playbook_check
 #    extra_tests
 


### PR DESCRIPTION
install package so that the restorecon command is available

Also copy in memtest.0 to the DocumentRoot of the web server (so it can be fetched during PXE boot)