### PR TITLE
Sorting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,7 @@ dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True
+dhcp_kickstart_skip_these_groups:
+ - "{{ dhcp_pxe_group }}"
+ - "all"
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,13 +82,13 @@
 - name: create_pxe_boot_data
   template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ item | regex_replace('^([^\.]*).*$', '\\1')  }}.conf"
   tags: dhcp_kickstart_config
-  with_items: "{{ groups[dhcp_pxe_group] }}"
+  with_items: "{{ groups[dhcp_pxe_group]|sort }}"
   when: groups[dhcp_pxe_group] is defined
 
 - name: create_kickstart_group_files
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"
   tags: dhcp_kickstart_config
-  with_items: "{{ groups }}"
+  with_items: "{{ groups|sort }}"
   when:
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,7 @@
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
   when:
+    - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
 

--- a/templates/dhcp_nodes.conf
+++ b/templates/dhcp_nodes.conf
@@ -1,5 +1,5 @@
-# Hosts
-{% for item in groups[dhcp_group] %}
+# {{ ansible_managed }}
+{% for item in groups[dhcp_group]|sort %}
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};

--- a/templates/dhcp_pxe_nodes.conf
+++ b/templates/dhcp_pxe_nodes.conf
@@ -1,5 +1,5 @@
-# Hosts
-{% for item in groups[dhcp_pxe_group] %}
+# {{ ansible_managed }}
+{% for item in groups[dhcp_pxe_group]|sort %}
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -121,7 +121,7 @@ function test_playbook(){
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || (echo "second ansible run failed" && exit 3 )
 
     echo "TEST: 3 idempotence test! Same as previous but now grep for changed=0.*failed=0"
-    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail but we exit 0 anyway until https://github.com/CSCfi/ansible-role-dhcp-kickstart/issues/13 is fixed' && exit 0)
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,13 @@
    remote_user: root
    vars:
      - dhcp_kickstart_handle_dhcpd: False
+     - dhcp_kickstart_skip_these_groups:
+        - "{{ dhcp_pxe_group }}"
+        - "all"
+        - "production"
+        - "pxe_bootable_nodes"
+        - "slurm_compute"
+        - "slurm_service"
    pre_tasks:
      - name: install dhcpd
        package:


### PR DESCRIPTION
Sorting of lists in ansible templates
-------

Because grand parent groups (group of groups) the groups might be returned in a different order and in result also the hosts would end up in a different order and then ansible would put the hosts in these templates in a different order.

So we call jinja2 | sort on the lists.

Grand parents
------------

```
[dhcp_pxe_hosts:children]
parent1
parent2

[parent1:children]
compute_group1
compute_group2

[parent2:children]
compute_group3
compute_group4

[compute_group1]
host1
[compute_group2]
host2
[compute_group3]
host3
[compute_group4]
host4
```

With an inventory like above which is similar to what we use in production, where both compute_group1 and compute_group2 have os_disks defined. Then when this role runs it would also generate kickstart configs for parent1 and parent2. But because the order in which the child groups are added the actually resulting config for the parent1/2 would be different sometimes depending which compute_group won.

So with that we with this PR add the possibility to skip some lists. At least for use the parent and dhcp_pxe_host groups would not change very often.