### PR TITLE
Store PXE config in JSON instead of one file per host = 10x speed improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Mandatory:
 Optional:
  - kernel_numa_param(can be set to off)
 
+Touch a file to start a reinstall
+----------------------
+
+If the hostname of a node you want to PXE / kickstart is computenode1.cloud.example.org then you need to touch either
+
+ - /var/www/provision/memtest86/computenode1
+ - or /var/www/provision/reinstall/computenode1
+
+Then when the node boots it will fetch http://ip/cgi-bin/boot.py and that python script will check if that the short hostname of the reverse DNS lookup of the IP/REMOTE_ADDR fetching the file exists and if so return ipxe lines for for example memtest86 or a kickstart reinstall.
+
 
 Caveats
 -------
@@ -79,3 +89,8 @@ dhcp_kickstart_install_chrony: True
 </pre>
 
 to keep chrony.
+
+Other OS than RHEL
+----------
+
+https://github.com/CSCfi/ansible-role-dhcp-kickstart/tree/SoneraCloud_PR_rebase is a PR which has some support for SUSE. It would need quite a bit of work to make it fit with current setup.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+hosts_file_pxe_group_to_populate: "{{ groups.dhcp_pxe_hosts }}"
+
 dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
 dhcp_kickstart_install_chrony: False

--- a/files/boot.py
+++ b/files/boot.py
@@ -29,10 +29,10 @@ syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_INFO))
 try:
     FQDN = socket.gethostbyaddr(os.environ["REMOTE_ADDR"])[0]
     HOSTNAME = FQDN.split(".")[0]
-except Exception as e:
+except Exception as e_xcep:
     syslog.syslog(
         syslog.LOG_ERR,
-        str(e) + " HOSTNAME wasn't found in /var/www/provision/nodes/pxe_nodes.json",
+        str(e_xcep) + " HOSTNAME wasn't found in /var/www/provision/nodes/pxe_nodes.json",
     )
     pxe_abort()
 
@@ -68,11 +68,11 @@ except OSError:
 # Catch all other problems
 except Exception as exc:
     # print(str(exc))
-    syslog.syslog(syslog.LOG_ERR, str(exc))
+    syslog.syslog(syslog.LOG_ERR, "Error: " + str(exc))
 
 ######## Reinstall
 
-if STARTED == False:
+if not STARTED:
     try:
         os.stat("/var/www/provision/reinstall/" + HOSTNAME)
         os.remove("/var/www/provision/reinstall/" + HOSTNAME)
@@ -109,6 +109,6 @@ if STARTED == False:
     # Catch all other problems
     except Exception as exc:
         print(str(exc))
-        syslog.syslog(syslog.LOG_ERR, str(exc))
+	syslog.syslog(syslog.LOG_ERR, "Error for " + HOSTNAME + ": " + str(exc))
 
 syslog.closelog()

--- a/files/boot.py
+++ b/files/boot.py
@@ -42,11 +42,12 @@ syslog.syslog(syslog.LOG_DEBUG, "Got boot iPXE request from " + HOSTNAME + "(" +
 STARTED = False
 # When a hypervisor restarts without a reinstall/memtest it is expected that the tries fails.
 try:
-    # for convenience create a file called HOSTNAME == short hostname
+    # for convenience admins on the web server that houses boot.py
+    #  needs to create a file called HOSTNAME == short hostname and not FQDN
     os.stat("/var/www/provision/memtest86/" + HOSTNAME)
     os.remove("/var/www/provision/memtest86/" + HOSTNAME)
 
-    # pxe_nodes.json has whatever is in the ansible inventory which might be the
+    #  pxe_nodes.json however has whatever is in the ansible inventory which might be the
     #  inconveniently long FQDN
     with open("/var/www/provision/nodes/pxe_nodes.json") as f:
         j = json.load(f)
@@ -109,6 +110,6 @@ if not STARTED:
     # Catch all other problems
     except Exception as exc:
         print(str(exc))
-	syslog.syslog(syslog.LOG_ERR, "Error for " + HOSTNAME + ": " + str(exc))
+        syslog.syslog(syslog.LOG_ERR, "Error for " + HOSTNAME + ": " + str(exc))
 
 syslog.closelog()

--- a/files/boot.py
+++ b/files/boot.py
@@ -53,16 +53,7 @@ try:
     NODESETTINGS = j[FQDN]
 
     syslog.syslog(syslog.LOG_INFO, "Memtesting node " + HOSTNAME)
-    NODESETTINGS = {}
-    for line in f.readlines():
-        # for every line, e.g. "key=value", set NODESETTINGS["key"]="value"
-        # comment lines will throw an error, skip them
-        try:
-            NODESETTINGS[line.split("=")[0]] = line.split("=", 1)[1].strip()
-        except:
-            pass
 
-    f.close()
     # http://forum.ipxe.org/showthread.php?tid=7937&highlight=memtest
     # https://git.ipxe.org/people/mcb30/memtest.git/commitdiff/fac651cb5f52f4dc2435c5c11ada06215a5b9ec9
     # there is no "pxe" referenced in memtest86+ 7.5 source code (found inside the iso)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,7 @@
 
 - name: template pxe boot data json file
   template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json'
+  tags: pxe_data
 
 - name: create_kickstart_group_files
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,11 +79,8 @@
   register: reg_selinux_apache
   changed_when: reg_selinux_apache.rc != 0 or reg_selinux_apache.stdout != ""
 
-- name: create_pxe_boot_data
-  template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ item | regex_replace('^([^\.]*).*$', '\\1')  }}.conf"
-  tags: dhcp_kickstart_config
-  with_items: "{{ groups[dhcp_pxe_group]|sort }}"
-  when: groups[dhcp_pxe_group] is defined
+- name: template pxe boot data json file
+  template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json'
 
 - name: create_kickstart_group_files
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"

--- a/templates/dhcp_nodes.conf
+++ b/templates/dhcp_nodes.conf
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 {% for item in groups[dhcp_group]|sort %}
 host {{ item }} {
-  hardware ethernet {{ hostvars[item]['mac_address'] }};
+  hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};
 }
 {% endfor %}

--- a/templates/pxe_node.conf
+++ b/templates/pxe_node.conf
@@ -1,8 +1,0 @@
-kickstart_url={{ hostvars[item]['kickstart_url'] }}
-kernel_url_path={{ hostvars[item]['kernel_url_path'] }}
-{% if 'extra_kernel_params' in hostvars[item] %}
-extra_kernel_params={{ hostvars[item]['extra_kernel_params'] }}
-{% endif %}
-{% if 'memtest86_0_path' in hostvars[item] %}
-memtest86_0_path={{ hostvars[item]['memtest86_0_path'] }}
-{% endif %}

--- a/templates/pxe_nodes.json.j2
+++ b/templates/pxe_nodes.json.j2
@@ -1,14 +1,15 @@
 {
-{% for item in dhcp_pxe_group %}
+{% for item in hosts_file_pxe_group_to_populate %}
   "{{ item }}": {
-    "kickstart_profile": "{{ hostvars[item]['kickstart_profile'] }}",
-    "kickstart_server_ip": "{{ hostvars[item]['kickstart_server_ip'] }}"
+    "kickstart_url": "{{ hostvars[item]['kickstart_url'] }}",
 {% if 'extra_kernel_params' in hostvars[item] %}
     "extra_kernel_params": "{{ hostvars[item]['extra_kernel_params'] }}",
 {% endif %}
 {% if 'memtest86_0_path' in hostvars[item] %}
-    "memtest86_0_path": "{{ hostvars[item]['memtest86_0_path'] }}"
-  }{% endif %}{% if not loop.last %},
+    "memtest86_0_path": "{{ hostvars[item]['memtest86_0_path'] }}",
+{% endif %}
+    "kernel_url_path": "{{ hostvars[item]['kernel_url_path'] }}"
+  }{% if not loop.last %},
 {% endif %}
 {% endfor %}
 

--- a/templates/pxe_nodes.json.j2
+++ b/templates/pxe_nodes.json.j2
@@ -1,5 +1,5 @@
 {
-{% for item in hosts_file_pxe_group_to_populate %}
+{% for item in hosts_file_pxe_group_to_populate|sort %}
   "{{ item }}": {
     "kickstart_url": "{{ hostvars[item]['kickstart_url'] }}",
 {% if 'extra_kernel_params' in hostvars[item] %}

--- a/templates/pxe_nodes.json.j2
+++ b/templates/pxe_nodes.json.j2
@@ -1,0 +1,15 @@
+{
+{% for item in dhcp_pxe_group %}
+  "{{ item }}": {
+    "kickstart_profile": "{{ hostvars[item]['kickstart_profile'] }}",
+    "kickstart_server_ip": "{{ hostvars[item]['kickstart_server_ip'] }}"
+{% if 'extra_kernel_params' in hostvars[item] %}
+    "extra_kernel_params": "{{ hostvars[item]['extra_kernel_params'] }}",
+{% endif %}
+{% if 'memtest86_0_path' in hostvars[item] %}
+    "memtest86_0_path": "{{ hostvars[item]['memtest86_0_path'] }}"
+  }{% endif %}{% if not loop.last %},
+{% endif %}
+{% endfor %}
+
+}

--- a/tests/group_vars/compute1/vars.yml
+++ b/tests/group_vars/compute1/vars.yml
@@ -3,4 +3,5 @@
 ip_address: '127.0.1.1'
 mac_address: "00:00:00:00:aa:c1"
 os_disks: "sda"
+extra_kernel_params: "blacklist=megaraid"
 ...

--- a/tests/group_vars/compute2/vars.yml
+++ b/tests/group_vars/compute2/vars.yml
@@ -1,3 +1,4 @@
 ip_address: '127.0.0.2'
 mac_address: "00:00:00:00:aa:c2"
 os_disks: 'sdb'
+memtest86_0_path: "http://10.1.1.1/memtest.0"

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -125,7 +125,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    ${APACHE_CTL} configtest || (echo "php --version was failed" && exit 100 )
+    echo "TEST: cat pxe_nodes.json"
+    cat /var/www/provision/nodes/pxe_nodes.json
 }
 
 
@@ -140,7 +141,7 @@ function main(){
     test_playbook_syntax
     test_playbook
 #    test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -129,6 +129,10 @@ function extra_tests(){
     cat /var/www/provision/nodes/pxe_nodes.json
     echo "TEST: valid JSON: python json.loads(pxe_nodes.json)"
     python tests/test_json.py
+    echo "TEST: curl http://localhost/cgi-bin/boot.py"
+    curl http://localhost/cgi-bin/boot.py
+    echo "TEST: curl http://localhost/cgi-bin/boot.py and grep for pxe"
+    curl -s http://localhost/cgi-bin/boot.py|grep pxe
 }
 
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -127,6 +127,8 @@ function extra_tests(){
 
     echo "TEST: cat pxe_nodes.json"
     cat /var/www/provision/nodes/pxe_nodes.json
+    echo "TEST: valid JSON: python json.loads(pxe_nodes.json)"
+    python tests/test_json.py
 }
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,8 @@
+""" test that the pxe_nodes.json and ansible template is valid JSON """
+
+import json
+
+with open('/var/www/provsion/nodes/pxe_nodes.json') as json_file:                 
+   data = json.load(json_file)     
+   # If we can't load it it's not valid according to the python json library
+   # For example is a comma is missing somewhere python will giev a ValueError when loading it

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2,7 +2,7 @@
 
 import json
 
-with open('/var/www/provsion/nodes/pxe_nodes.json') as json_file:                 
-   data = json.load(json_file)     
-   # If we can't load it it's not valid according to the python json library
-   # For example is a comma is missing somewhere python will giev a ValueError when loading it
+with open('/var/www/provision/nodes/pxe_nodes.json') as json_file:
+    DATA = json.load(json_file)
+    # If we can't load it it's not valid according to the python json library
+    # For example is a comma is missing somewhere python will giev a ValueError when loading it


### PR DESCRIPTION
To do this I have copied lines of code and adjusted them from https://github.com/CSCfi/ansible-role-pxe_bootstrap/blob/master/files/boot.py

I do not know what is the most open source friendly way of doing this other than referencing the use of this code in this PR and in commits. Copying in the file and then using it as a base would be wrong. The original is anyway boot.py from this repo (ansible-role-dhcp-kickstart)..

Plenty of other changes also possible to incorporate from https://github.com/CSCfi/ansible-role-pxe_bootstrap and https://github.com/CSCfi/ansible-role-pxe_config 
For example new files used to UEFI boot and a new snponly something. 

To test that the boot.py returns what it did before one can test it like this:
 - before running ansible, touch the reinstall file and curl http://ip/cgi-bin/boot.py
 - after ansible to update boot.py and add the pxe_nodes.json, touch reinstall file and curl again
 - the output should be identical

The slowness before was the looping and templating in as many files as one had hosts in the ansible groups that was set to PXE boot. In our case several hundreds. This is now slimmed down to one single ansible template task.

Tested (already running) on epouta-gw1