### PR TITLE
More kickstart settings and more testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/CSCfi/ansible-role-dhcp-kickstart.svg?branch=master)](https://travis-ci.org/CSCfi/ansible-role-dhcp-kickstart)
 
-Spacewalk proxy  Ansible role
+DHCP/PXE privisioning Ansible role
 =============================
 
 This is an Ansible role for configuring PXE/iPXE provisioning, either by
@@ -39,10 +39,22 @@ Mandatory:
  - kernel_url_path (path where kickstart kernel and initrd can be found)
 
 Optional:
- - serialport (for kickstart)
- - extra_kernel_params (for the kickstart)
+ - serialport (for during kickstart)
+ - extra_kernel_params (for during kickstart)
  - dhcp_domain
  - memtest86_0_path (for pointing to a memtest.0 PXE NBP)
+ - kickstart_grubby_remove_args (for adjusting grub config on default kernel at the end of the kickstart)
+ - kickstart_grubby_args
+ - yum_proxy (if defined is used also in the url and repo bits of the kickstart)
+ - kickstart_lang
+ - kickstart_keyboard
+ - kickstart_timezone
+ - kickstart_log_host
+ - dhcp_kickstart_manage_packages
+ - kickstart_packages
+ - kickstart_extra_pre_option
+ - kickstart_extra_pre_commands
+ - kickstart_extra_post_commands
 
 The nodes which only need to be set up for DHCP need to be in the
 (by default) "dhcp_only_nodes"  group. These nodes need the following 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Mandatory:
  - kernel_url_path (path where kickstart kernel and initrd can be found)
 
 Optional:
+ - serialport (for kickstart)
  - extra_kernel_params (for the kickstart)
  - dhcp_domain
  - memtest86_0_path (for pointing to a memtest.0 PXE NBP)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ This role assumes that a ISC DHCP server has been set up by another role.
 Usage
 -----
 
-This role works by setting up pxe booting based on groups. It configures PXE
+This role works by setting up pxe booting based on **groups**. It configures PXE
 booting for all hosts in the desired group. By default it's "dhcp_pxe_nodes",
 but it can be defined (check defaults/main.yml)
+
+It sets up kickstarts for every ansible **group** under dhcp_pxe_nodes (more details in the Caveats section)
 
 Each host needs the follwing variables in its scope.
 
@@ -102,6 +104,22 @@ dhcp_kickstart_install_chrony: True
 </pre>
 
 to keep chrony.
+
+Why we use hostvars[groups[item][0]]['variablename'] when templating in the kickstarts
+-----
+
+This role sets up kickstarts for every ansible **group** under dhcp_pxe_nodes.
+
+This last bit makes this role a bit different than many other ansible roles.
+
+Templating in the kickstart config files are done per group and not per host.
+
+This is why we use the weird hostvars[groups[item][0]]['variable']
+
+If one were to use the {{ variablename }} and you use ansible groups with parents of parents (grand parents? :)
+then the variable that ends up in the final file might vary depending on which parent group gets put earlier
+in the ansible python unordered list. If you can make this role work without using hostvars I'll buy you a beer.
+
 
 Other OS than RHEL
 ----------

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Optional:
  - kickstart_timezone
  - kickstart_log_host
  - dhcp_kickstart_manage_packages
- - kickstart_packages
+ - kickstart_packages # if dhcp_kickstart_manage_packages is defined then kickstart_packages must contain %packages
  - kickstart_extra_pre_option
  - kickstart_extra_pre_commands
  - kickstart_extra_post_commands

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True
-dhcp_kickstart_default_packages: True
 dhcp_kickstart_skip_these_groups:
  - "{{ dhcp_pxe_group }}"
  - "all"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True
+dhcp_kickstart_default_packages: True
 dhcp_kickstart_skip_these_groups:
  - "{{ dhcp_pxe_group }}"
  - "all"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,6 @@ dhcp_kickstart_handle_dhcpd: True
 dhcp_kickstart_skip_these_groups:
  - "{{ dhcp_pxe_group }}"
  - "all"
-kickstart_grubby_args: "console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
+kickstart_grubby_args: "console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa=on"
 #kickstart_grubby_remove_args: ""
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,6 @@ dhcp_kickstart_handle_dhcpd: True
 dhcp_kickstart_skip_these_groups:
  - "{{ dhcp_pxe_group }}"
  - "all"
+kickstart_grubby_args: "console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
+#kickstart_grubby_remove_args: ""
 ...

--- a/files/boot.py
+++ b/files/boot.py
@@ -82,7 +82,8 @@ if not STARTED:
             j = json.load(f)
         NODESETTINGS = j[FQDN]
 
-        SERIALPORT = "ttyS1"
+        # default sets up both serial and console
+        SERIALPORT = "console=ttyS1,115200 console=tty0"
         EXTRA_KERNEL_PARAMS = ""
         if "serialport" in NODESETTINGS:
             SERIALPORT = NODESETTINGS["serialport"]
@@ -96,9 +97,9 @@ if not STARTED:
             + NODESETTINGS["kernel_url_path"]
             + "/vmlinuz ks="
             + NODESETTINGS["kickstart_url"]
-            + " edd=off ksdevice=bootif kssendmac console="
+            + " edd=off ksdevice=bootif kssendmac "
             + SERIALPORT
-            + ",115200 console=tty0 initrd=initrd.img "
+            + "initrd=initrd.img "
             + EXTRA_KERNEL_PARAMS
         )
         print("initrd " + NODESETTINGS["kernel_url_path"] + "/initrd.img")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,11 +83,11 @@
   changed_when: reg_selinux_apache.rc != 0 or reg_selinux_apache.stdout != ""
 
 - name: template pxe boot data json file
-  template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json'
+  template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json' backup=yes
   tags: pxe_data
 
 - name: create_kickstart_group_files
-  template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s'
+  template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,10 +87,9 @@
   tags: pxe_data
 
 - name: create_kickstart_group_files
-  template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"
+  template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s'
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
-  validate: '/usr/bin/ksvalidator %s'
   when:
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
 - name: install_xinetd
   yum: name='xinetd' state='present'
 
+- name: install_pykickstart for ksvalidator
+  yum: name='pykickstart' state='present'
+
 - name: install_tftp-server
   yum: name='tftp-server' state='present'
 
@@ -87,6 +90,7 @@
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks"
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
+  validate: '/usr/bin/ksvalidator %s'
   when:
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -19,11 +19,11 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }} --proxy={{ hostvars[groups[
 repo --name={{ repo.name }} --baseurl={{ repo.url }}
 {% endif %}
 {% endfor %}
-lang en_US.UTF-8
-keyboard fi-latin1
+lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
+keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
 bootloader --location=mbr --append elevator=deadline
-timezone Europe/Helsinki
+timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --disabled
@@ -43,6 +43,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ line }}
 {% endfor %}
 
+{% if dhcp_kickstart_default_packages == true %}
 %packages
 @ Base
 -NetworkManager
@@ -58,6 +59,10 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -chrony
 {% endif %}
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
+{% else %}
+%packages
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -2,12 +2,13 @@ install
 text
 network --noipv6
 
-# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
-# Ansible has no way of accessing a group's variables, so they are accessed
-# via the first host of the group.
+{% if yum_proxy is defined %}
+url --url {{ install_repo }} --proxy={{ yum_proxy }}
+{% else %}
+url --url {{ install_repo }}
+{% endif %}
 
-url --url {{ hostvars[groups[item][0]]['install_repo'] }}
-{% for repo in hostvars[groups[item][0]]['additional_repos'] %}
+{% for repo in additional_repos %}
 repo --name={{ repo.name }} --baseurl={{ repo.url }}
 {% endfor %}
 lang en_US.UTF-8
@@ -16,17 +17,17 @@ zerombr
 bootloader --location=mbr --append elevator=deadline
 timezone Europe/Helsinki
 auth --enableshadow --passalgo=sha512
-rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
+rootpw --iscrypted {{ root_password_hash }}
 selinux --disabled
 reboot
 firewall --service=ssh
 skipx
 services --enabled=ntpd
 
-clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
-ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
+clearpart --all --drives={{ os_disks }} --initlabel
+ignoredisk --only-use={{ os_disks }}
 
-{% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}
+{% for line in kickstart_partitions %}
 {{ line }}
 {% endfor %}
 
@@ -48,7 +49,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1
 mkdir -p /root/.ssh
-{% for key in hostvars[groups[item][0]]['root_keys'] %}
+{% for key in root_keys %}
 echo "{{ key }}" >> /root/.ssh/authorized_keys
 {% endfor %}
 chmod 700 /root/.ssh
@@ -73,6 +74,6 @@ systemctl disable NetworkManager
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
 
-/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ kernel_numa_param | default('on') }}"
 # End post install kernel options update
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -58,7 +58,9 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
 {% endif %}
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
 %end
 
 {% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -33,7 +33,6 @@ skipx
 services --enabled=ntpd
 
 {% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}
-# Logging
 logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
 {% endif %}
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -63,7 +63,9 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endif %}
 {% else %}
 %packages
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
 {% endif %}
 %end
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -43,7 +43,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ line }}
 {% endfor %}
 
-{% if dhcp_kickstart_default_packages == true %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_default_packages'] == true %}
 %packages
 @ Base
 -NetworkManager

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -32,9 +32,9 @@ firewall --service=ssh
 skipx
 services --enabled=ntpd
 
-{% if hostvars[groups[item][0]]['central_log_host'] is defined %}
+{% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}
 # Logging
-logging --host={{ hostvars[groups[item][0]]['central_log_host'] }}
+logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
 {% endif %}
 
 clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -43,7 +43,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ line }}
 {% endfor %}
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_default_packages'] == true %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 %packages
 @ Base
 -NetworkManager

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -109,6 +109,10 @@ echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
 {{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}
 {% endif %}
 
-/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
+{% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined %}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}" --remove-args="{{ kickstart_grubby_remove_args }}"
+{% else %}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}"
+{% endif %}
 # End post install kernel options update
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -55,26 +55,22 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -NetworkManager-glib
 -NetworkManager-team
 -NetworkManager-wwan
-{% if dhcp_kickstart_install_chrony == false %}
+  {% if dhcp_kickstart_install_chrony == false -%}
 -chrony
+  {%- endif %}
 {% endif %}
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
-{% endif %}
-{% else %}
-{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
-{{ hostvars[groups[item][0]]['kickstart_packages'] }}
-{% endif %}
 {% endif %}
 %end
 
 {% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}
-{% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined %}
+  {% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined -%}
 ####### Extra PRE commands
 {{ hostvars[groups[item][0]]['kickstart_pre_option'] }}
 {{ hostvars[groups[item][0]]['kickstart_extra_pre_commands'] }}
 %end
-{% endif %}
+  {%- endif %}
 {% endif %}
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -6,9 +6,18 @@ network --noipv6
 # Ansible has no way of accessing a group's variables, so they are accessed
 # via the first host of the group.
 
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
 url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+{% endif %}
+
 {% for repo in hostvars[groups[item][0]]['additional_repos'] %}
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+repo --name={{ repo.name }} --baseurl={{ repo.url }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
 repo --name={{ repo.name }} --baseurl={{ repo.url }}
+{% endif %}
 {% endfor %}
 lang en_US.UTF-8
 keyboard fi-latin1
@@ -22,6 +31,11 @@ reboot
 firewall --service=ssh
 skipx
 services --enabled=ntpd
+
+{% if hostvars[groups[item][0]]['central_log_host'] is defined %}
+# Logging
+logging --host={{ hostvars[groups[item][0]]['central_log_host'] }}
+{% endif %}
 
 clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
 ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
@@ -44,7 +58,17 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
 {% endif %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
 %end
+
+{% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}
+{% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined %}
+####### Extra PRE commands
+{{ hostvars[groups[item][0]]['kickstart_pre_option'] }}
+{{ hostvars[groups[item][0]]['kickstart_extra_pre_commands'] }}
+%end
+{% endif %}
+{% endif %}
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1
 mkdir -p /root/.ssh
@@ -72,6 +96,11 @@ systemctl disable NetworkManager
 # Disable Ipv6 at the kernel level
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+
+{% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
+####### Extra POST commands
+{{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}
+{% endif %}
 
 /sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
 # End post install kernel options update

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -109,10 +109,12 @@ echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
 {{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}
 {% endif %}
 
-{% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined %}
+{% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
 /sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}" --remove-args="{{ hostvars[groups[item][0]]['kickstart_grubby_remove_args'] }}"
-{% else %}
+{% elif hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is not defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
 /sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}"
+{% else %}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}"
 {% endif %}
 # End post install kernel options update
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -2,13 +2,12 @@ install
 text
 network --noipv6
 
-{% if yum_proxy is defined %}
-url --url {{ install_repo }} --proxy={{ yum_proxy }}
-{% else %}
-url --url {{ install_repo }}
-{% endif %}
+# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
+# Ansible has no way of accessing a group's variables, so they are accessed
+# via the first host of the group.
 
-{% for repo in additional_repos %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+{% for repo in hostvars[groups[item][0]]['additional_repos'] %}
 repo --name={{ repo.name }} --baseurl={{ repo.url }}
 {% endfor %}
 lang en_US.UTF-8
@@ -17,17 +16,17 @@ zerombr
 bootloader --location=mbr --append elevator=deadline
 timezone Europe/Helsinki
 auth --enableshadow --passalgo=sha512
-rootpw --iscrypted {{ root_password_hash }}
+rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --disabled
 reboot
 firewall --service=ssh
 skipx
 services --enabled=ntpd
 
-clearpart --all --drives={{ os_disks }} --initlabel
-ignoredisk --only-use={{ os_disks }}
+clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
+ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 
-{% for line in kickstart_partitions %}
+{% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}
 {{ line }}
 {% endfor %}
 
@@ -49,7 +48,7 @@ ignoredisk --only-use={{ os_disks }}
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1
 mkdir -p /root/.ssh
-{% for key in root_keys %}
+{% for key in hostvars[groups[item][0]]['root_keys'] %}
 echo "{{ key }}" >> /root/.ssh/authorized_keys
 {% endfor %}
 chmod 700 /root/.ssh
@@ -74,6 +73,6 @@ systemctl disable NetworkManager
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
 
-/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ kernel_numa_param | default('on') }}"
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
 # End post install kernel options update
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -55,9 +55,9 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -NetworkManager-glib
 -NetworkManager-team
 -NetworkManager-wwan
-  {% if dhcp_kickstart_install_chrony == false -%}
+{% if dhcp_kickstart_install_chrony == false %}
 -chrony
-  {%- endif %}
+{% endif %}
 {% endif %}
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
@@ -65,12 +65,12 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 %end
 
 {% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}
-  {% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined -%}
+{% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined %}
 ####### Extra PRE commands
 {{ hostvars[groups[item][0]]['kickstart_pre_option'] }}
 {{ hostvars[groups[item][0]]['kickstart_extra_pre_commands'] }}
 %end
-  {%- endif %}
+{% endif %}
 {% endif %}
 
 %post --interpreter /bin/bash --log /root/ks-post.log.1

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -110,9 +110,9 @@ echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
 {% endif %}
 
 {% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined %}
-/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}" --remove-args="{{ kickstart_grubby_remove_args }}"
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}" --remove-args="{{ hostvars[groups[item][0]]['kickstart_grubby_remove_args'] }}"
 {% else %}
-/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}"
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}"
 {% endif %}
 # End post install kernel options update
 %end

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -62,7 +62,6 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}
 {% else %}
-%packages
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}

--- a/templates/pxe_nodes.json.j2
+++ b/templates/pxe_nodes.json.j2
@@ -8,6 +8,9 @@
 {% if 'memtest86_0_path' in hostvars[item] %}
     "memtest86_0_path": "{{ hostvars[item]['memtest86_0_path'] }}",
 {% endif %}
+{% if 'serialport' in hostvars[item] %}
+    "serialport": "{{ hostvars[item]['serialport'] }}",
+{% endif %}
     "kernel_url_path": "{{ hostvars[item]['kernel_url_path'] }}"
   }{% if not loop.last %},
 {% endif %}

--- a/tests/group_vars/admin/vars.yml
+++ b/tests/group_vars/admin/vars.yml
@@ -1,3 +1,16 @@
 os_disks: 'sde'
 ip_address: '127.0.0.1'
 mac_address: "00:00:00:00:aa:aa"
+kickstart_packages: |
+  ansible
+  git
+yum_proxy: "http://myproxy.example.org:3128"
+
+kickstart_pre_option: "%pre --interpreter=/usr/bin/python --log=/mnt/sysimage/root/ks-pre.log"
+kickstart_extra_pre_commands: |
+ 'print("no extra kickstart pre commands defined")'
+
+kickstart_extra_post_commands: |
+ "echo no extra kickstart post commands defined"
+
+kickstart_log_host: "10.2.2.2"

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -21,4 +21,5 @@ kickstart_partitions:
  - "logvol /tmp --fstype=ext4 --name=tmp --vgname=vg.os --size=10240"
 root_keys:
  - "ssh-rsa key"
+ - "ssh-rsa key2"
 ...

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -9,7 +9,7 @@ kernel_url_path: "http://{{ dhcp_server_ip }}/centos.org/7/os/x86_64//isolinux"
 install_repo: "http://{{ dhcp_server_ip }}/centos.org/7/os/x86_64/"
 additional_repos:
  - name: "CentOS_Updates"
-   url: "http://{{ dhcp_server_ip }}centos.org/7/updates/x86_64/"
+   url: "http://{{ dhcp_server_ip }}/centos.org/7/updates/x86_64/"
 root_password_hash: "$1lolhash"
 kickstart_partitions:
  - "part /boot --fstype ext4 --size=512 --ondisk=sda"

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -2,6 +2,7 @@ ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
 memtest86_0_path: "http://10.1.1.1/memtest.0"
 os_disks: 'sdc'
+serialport: "console=ttyS1,115200"
 kernel_numa_param: "off"
 dhcp_kickstart_manage_packages: "anything"
 kickstart_packages: |

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -11,4 +11,4 @@ kickstart_packages: |
   vim-enhanced
   openssh-clients
 kickstart_grubby_remove_args: "rhgb quiet"
-kickstart_grubby_args: "console=tty0 console=ttyS1,115200 ipv6.disable=1 numa=on
+kickstart_grubby_args: "{{ serialport }} ipv6.disable=1 numa={{ kernel_numa_param }}"

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -11,4 +11,4 @@ kickstart_packages: |
   vim-enhanced
   openssh-clients
 kickstart_grubby_remove_args: "rhgb quiet"
-kickstart_grubby_args: "console=tty0 console=ttyS1,115200 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"
+kickstart_grubby_args: "console=tty0 console=ttyS1,115200 ipv6.disable=1 numa=on

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -1,3 +1,4 @@
 ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
 os_disks: 'sdc'
+kernel_numa_param: "on rhgb quiet"

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -2,3 +2,9 @@ ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
 os_disks: 'sdc'
 kernel_numa_param: "on rhgb quiet"
+dhcp_kickstart_default_packages: False
+kickstart_packages: |
+  %packages --nobase
+  @core
+  vim-enhanced
+  openssh-clients

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -2,7 +2,7 @@ ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
 os_disks: 'sdc'
 kernel_numa_param: "on rhgb quiet"
-dhcp_kickstart_default_packages: False
+dhcp_kickstart_manage_packages: "anything"
 kickstart_packages: |
   %packages --nobase
   @core

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -2,10 +2,12 @@ ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
 memtest86_0_path: "http://10.1.1.1/memtest.0"
 os_disks: 'sdc'
-kernel_numa_param: "on rhgb quiet"
+kernel_numa_param: "off"
 dhcp_kickstart_manage_packages: "anything"
 kickstart_packages: |
   %packages --nobase
   @core
   vim-enhanced
   openssh-clients
+kickstart_grubby_remove_args: "rhgb quiet"
+kickstart_grubby_args: "console=tty0 console=ttyS1,115200 ipv6.disable=1 numa={{ hostvars[groups[item][0]]['kernel_numa_param'] | default('on') }}"

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -1,5 +1,6 @@
 ip_address: '127.0.0.3'
 mac_address: "00:00:00:00:aa:c3"
+memtest86_0_path: "http://10.1.1.1/memtest.0"
 os_disks: 'sdc'
 kernel_numa_param: "on rhgb quiet"
 dhcp_kickstart_manage_packages: "anything"

--- a/tests/inventory
+++ b/tests/inventory
@@ -17,9 +17,6 @@ computenode11
 [compute2]
 computenode2
 computenode22
-[compute3]
-computenode3
-computenode33
 
 [dhcp_pxe_hosts:children]
 pxe_bootable_nodes
@@ -41,3 +38,9 @@ install
 compute1
 compute2
 compute3
+
+# compute3 group at bottom so as part of testing we can
+#  echo $HOSTNAME >> inventory
+[compute3]
+computenode3
+computenode33

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -144,11 +144,11 @@ function extra_tests(){
     echo "TEST: touch /var/www/provision/reinstall/${HOSTNAME}"
     touch /var/www/provision/reinstall/${HOSTNAME}
     echo "TEST: curl after touching the reinstall file and grep for the lines"
-    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e kernel -e init -e boot
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e ^kernel -e ^init -e ^boot
     echo "TEST: touch /var/www/provision/memtest86/${HOSTNAME}"
     touch /var/www/provision/memtest86/${HOSTNAME}
     echo "TEST: curl after touching the memtest86 file and grep for the lines"
-    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e boot
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e ^boot
 }
 
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -149,6 +149,10 @@ function extra_tests(){
     touch /var/www/provision/memtest86/${HOSTNAME}
     echo "TEST: curl after touching the memtest86 file and grep for the lines"
     curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e ^boot -e ^kernel
+    echo "TEST: grep for sdc in compute3's kickstart file because that's what we have in tests/group_vars/compute3/ ."
+    echo " If this fails there has been a backwards compatible breaking change"
+    grep sdc /var/www/html/kickstart/compute3.ks
+
 }
 
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -148,7 +148,7 @@ function extra_tests(){
     echo "TEST: touch /var/www/provision/memtest86/${HOSTNAME}"
     touch /var/www/provision/memtest86/${HOSTNAME}
     echo "TEST: curl after touching the memtest86 file and grep for the lines"
-    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e ^boot
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e ^boot -e ^kernel
 }
 
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -92,6 +92,14 @@ function test_ansible_setup(){
 
 }
 
+function add_server_to_inventory(){
+
+    echo "TEST: put ${HOSTNAME} into ${ANSIBLE_INVENTORY} ansible group compute3"
+
+    echo ${HOSTNAME} >> ${ANSIBLE_INVENTORY}
+
+}
+
 
 function test_install_requirements(){
     echo "TEST: ansible-galaxy install -r requirements.yml --force"
@@ -130,7 +138,7 @@ function extra_tests(){
     echo "TEST: valid JSON: python json.loads(pxe_nodes.json)"
     python tests/test_json.py
     echo "TEST: curl http://localhost/cgi-bin/boot.py"
-    curl http://localhost/cgi-bin/boot.py
+    curl -vv http://localhost/cgi-bin/boot.py
     echo "TEST: curl http://localhost/cgi-bin/boot.py and grep for pxe"
     curl -s http://localhost/cgi-bin/boot.py|grep pxe
 }
@@ -141,6 +149,7 @@ function main(){
 #    install_os_deps
 #    install_ansible_devel
     show_version
+    add_server_to_inventory
 #    tree_list
 #    test_install_requirements
     test_ansible_setup

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -137,10 +137,14 @@ function extra_tests(){
     cat /var/www/provision/nodes/pxe_nodes.json
     echo "TEST: valid JSON: python json.loads(pxe_nodes.json)"
     python tests/test_json.py
-    echo "TEST: curl http://localhost/cgi-bin/boot.py"
-    curl -vv http://localhost/cgi-bin/boot.py
-    echo "TEST: curl http://localhost/cgi-bin/boot.py and grep for pxe"
-    curl -s http://localhost/cgi-bin/boot.py|grep pxe
+    echo "TEST: curl http://${HOSTNAME}/cgi-bin/boot.py"
+    curl -vv http://${HOSTNAME}/cgi-bin/boot.py
+    echo "TEST: curl http://${HOSTNAME}/cgi-bin/boot.py and grep for pxe"
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep pxe
+    echo "TEST: touch /var/www/provision/reinstall/${HOSTNAME}"
+    touch /var/www/provision/reinstall/${HOSTNAME}
+    echo "TEST: curl after touching the reinstall file"
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py
 }
 
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -143,8 +143,12 @@ function extra_tests(){
     curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep pxe
     echo "TEST: touch /var/www/provision/reinstall/${HOSTNAME}"
     touch /var/www/provision/reinstall/${HOSTNAME}
-    echo "TEST: curl after touching the reinstall file"
-    curl -s http://${HOSTNAME}/cgi-bin/boot.py
+    echo "TEST: curl after touching the reinstall file and grep for the lines"
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e kernel -e init -e boot
+    echo "TEST: touch /var/www/provision/memtest86/${HOSTNAME}"
+    touch /var/www/provision/memtest86/${HOSTNAME}
+    echo "TEST: curl after touching the memtest86 file and grep for the lines"
+    curl -s http://${HOSTNAME}/cgi-bin/boot.py|grep -e pxe -e boot
 }
 
 


### PR DESCRIPTION
Testing
---
 - now we actually http get boot.py after the reinstall and the memtest86 files have been touched. This in travis/testing uses the hostname of the container where the test is running.  
 - also, grep the output from those curls to include the things we expect them to include
 - we also run ksvalidator from the pykickstart RPM on the kickstart files, not only in testing but also when the kickstart gets templated in. Meaning if one were to add something bad via variables that would result in an invalid kickstart config ansible gives an error. 
 - the changes to kickstart.j2 and boot.py are by defining variables in some places in group_vars. 
   - to test that the above works like it should, we now fail the travis build if grep for "sdc" for compute3 doesn't find anything

Lots of more variables one can use to define what will end up in the kickstart. None of them should be required
----

**To pxe_json or the boot.py:**

 - serialport #you can now define serialport configuration during anaconda/kickstarting
 - backup pxe_nodes.json file if it changes

**To kickstart.j2 configs:**

The below would need to be set for the group, so for example `group_vars/groupname/vars.yml` - it's not enough to specify them in group_vars/all.yml because of how we use hostvars[] to write the kickstart templates. More details about this bit added to [README.MD](README.MD)

 - kickstart_grubby_args #use this to define arguments to the default kernel (the one the OS will boot on after the kickstart). This is so one can use IPv6 if so desired or modify the consoles
 - kickstart_grubby_remove_args # use this to remove arguments from the grub of the default kernel. 
 - yum_proxy # if defined is used also in the url and repo bits
 - kickstart_lang #if undefined: en_US.UTF-8
 - kickstart_keyboard # if undefined: fi-latin1
 - kickstart_timezone # if undefined: Europe/Helsinki
 - kickstart_log_host # can be used to ship logs to a remote host during kickstart
 - dhcp_kickstart_manage_packages #if this is defined then kickstart_packages is expected to contain %packages. If it's not defined we keep the backwards compatible list of packages installed and uninstalled as before this PR
 - kickstart_packages #a string which is a list of packages to install or uninstall
 - kickstart_extra_pre_option # one can choose interpreter of the extra_pre_commands
 - kickstart_extra_pre_commands
 - kickstart_extra_post_commands # only bash for post_commands

As part of kickstart templates we now `backup=yes` the files, meaning if every time ansible template would change a kickstart file it would store a backup of the old file in the same directory