### PR TITLE
Prefix initrd with whitespace

### DIFF
--- a/files/boot.py
+++ b/files/boot.py
@@ -99,7 +99,7 @@ if not STARTED:
             + NODESETTINGS["kickstart_url"]
             + " edd=off ksdevice=bootif kssendmac "
             + SERIALPORT
-            + "initrd=initrd.img "
+            + " initrd=initrd.img "
             + EXTRA_KERNEL_PARAMS
         )
         print("initrd " + NODESETTINGS["kernel_url_path"] + "/initrd.img")


### PR DESCRIPTION
Otherwise the serial port string might hug the initrd definition
too closely, resulting in failure.