### PR TITLE
WIP - CentOS8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,20 @@ Optional:
  - kickstart_timezone
  - kickstart_log_host
  - dhcp_kickstart_manage_packages
- - kickstart_packages # if dhcp_kickstart_manage_packages is defined then kickstart_packages must contain %packages
+ - kickstart_packages # if dhcp_kickstart_manage_packages is defined, it must contain at least @Core or @Base
  - kickstart_extra_pre_option
  - kickstart_extra_pre_commands
  - kickstart_extra_post_commands
+ - dhcp_kickstart_centos_version set as "8" or "9" in order to skip old centos7 defaults, remember to define kickstart_packages like:
+    @core --nodefaults
+    -alsa-*
+    -ivtv*
+    -iwl*firmware
+
+ - dhcp_kickstart_disable_ipv6 set as False if ipv6 is needed
 
 The nodes which only need to be set up for DHCP need to be in the
-(by default) "dhcp_only_nodes"  group. These nodes need the following 
+(by default) "dhcp_only_nodes"  group. These nodes need the following
 variables.
 
  - mac_address

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Optional:
  - kickstart_timezone
  - kickstart_log_host
  - dhcp_kickstart_manage_packages
- - kickstart_packages # if dhcp_kickstart_manage_packages is defined, it must contain at least @Core or @Base
+ - kickstart_packages # if dhcp_kickstart_manage_packages is defined then kickstart_packages must contain at least @Core or @Base
  - kickstart_extra_pre_option
  - kickstart_extra_pre_commands
  - kickstart_extra_post_commands

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ hosts_file_pxe_group_to_populate: "{{ groups.dhcp_pxe_hosts }}"
 
 dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
+dhcp_kickstart_centos_version: "7"
+dhcp_kickstart_disable_ipv6: True
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True
 dhcp_kickstart_skip_these_groups:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,13 +3,10 @@ hosts_file_pxe_group_to_populate: "{{ groups.dhcp_pxe_hosts }}"
 
 dhcp_group: "dhcp_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
-dhcp_kickstart_centos_version: "7"
-dhcp_kickstart_disable_ipv6: True
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True
 dhcp_kickstart_skip_these_groups:
  - "{{ dhcp_pxe_group }}"
  - "all"
 kickstart_grubby_args: "console=tty0 console=ttyS1,19200n8 ipv6.disable=1 numa=on"
-#kickstart_grubby_remove_args: ""
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   tags: dhcp_kickstart_config
   notify:
     - restart dhcpd-kickstart
-    
+
 - name: install restorecon for selinux
   package:
     name: policycoreutils
@@ -93,7 +93,7 @@
   when:
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
-    - hostvars[groups[item][0]]['os_disks'] is defined
+    - hostvars[groups[item][0]]['os_disks'] is defined 
 
 - name: copy memtest.0 PXE NBP
   copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -150,11 +150,16 @@ systemctl stop NetworkManager
 systemctl disable NetworkManager
 {% endif %}
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is sameas true %}
 # Disable Ipv6 at the kernel level
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
-{%endif %}
+{% elif hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is sameas false %}
+# No-op.
+{% elif dhcp_kickstart_disable_ipv6 is sameas true %}
+echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+{% endif %}
 
 {% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
 ####### Extra POST commands

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -125,7 +125,9 @@ chmod 600 /root/.ssh/authorized_keys
 
 %post --interpreter /bin/bash --log /root/ks-post.log.2
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+# No-op.
+{% else %}
 # Add mellanox ethernet modules to autoload on boot. This way, if a host has a
 # mellanox card, it will come up in the ethernet mode.
 echo mlx4_en >>/etc/modules-load.d/mlx4.conf

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -50,26 +50,25 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
-bootloader --location=mbr --append elevator=deadline
-{% endif %}
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
 bootloader --location=mbr --append="rhgb quiet crashkernel=auto"
+{% else %}
+# Default to CentOS 7
+bootloader --location=mbr --append elevator=deadline
 {% endif %}
 
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
-selinux --disabled
-firewall --service=ssh
-services --enabled=ntpd
-{% endif %}
-
 {% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
 selinux --permissive
 firewall --enabled --ssh
+{% else %}
+# Default to CentOS 7
+selinux --disabled
+firewall --service=ssh
+services --enabled=ntpd
 {% endif %}
 
 {% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -5,6 +5,8 @@ skipx
 
 {% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
 network --noipv6
+{% else %}
+network
 {% endif %}
 
 # The hostvars[groups[item][0]]['install_repo'] pattern is used in this template

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -43,8 +43,8 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ line }}
 {% endfor %}
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 %packages
+{% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 @ Base
 -NetworkManager
 -NetworkManager-bluetooth
@@ -55,9 +55,9 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -NetworkManager-glib
 -NetworkManager-team
 -NetworkManager-wwan
+{% endif %}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
-{% endif %}
 {% endif %}
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -3,15 +3,15 @@ text
 reboot
 skipx
 
+# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
+# Ansible has no way of accessing a group's variables, so they are accessed
+# via the first host of the group.
+
 {% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
 network --noipv6
 {% else %}
 network
 {% endif %}
-
-# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
-# Ansible has no way of accessing a group's variables, so they are accessed
-# via the first host of the group.
 
 {% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
 url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -83,7 +83,17 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endfor %}
 
 %packages
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+# Always install these packages when defined in the group_vars.
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
+# If CentOS8 is set in the group, we do a...
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+# ...no-op.
+# For consideration: Might this be a good spot for @Core?
+{% else %}
+# Otherwise we default to CentOS7.
+# If user doesn't manage packages we provide some defaults.
 {% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 @ Base
 -NetworkManager
@@ -100,10 +110,6 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
 {% endif %}
-{% endif %}
-# Always install these packages when defined.
-{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
-{{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}
 %end
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -83,10 +83,6 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endfor %}
 
 %packages
-# Always install these packages when defined in the group_vars.
-{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
-{{ hostvars[groups[item][0]]['kickstart_packages'] }}
-{% endif %}
 # If CentOS8 is set in the group, we do a...
 {% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] == '8' %}
 # ...no-op.
@@ -110,6 +106,11 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
 {% endif %}
+{% endif %}
+# Always install these packages when defined in the group_vars.
+# Here we intentionally leave this last so @Base or @Core can kick in first.
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}
 %end
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -29,7 +29,7 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 bootloader --location=mbr --append elevator=deadline
 {% endif %}
 {% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
@@ -40,13 +40,13 @@ timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/He
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 selinux --disabled
 firewall --service=ssh
 services --enabled=ntpd
 {% endif %}
 
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
 selinux --permissive
 firewall --enabled --ssh
 {% endif %}
@@ -63,7 +63,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endfor %}
 
 %packages
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 {% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 @ Base
 -NetworkManager
@@ -105,7 +105,7 @@ chmod 600 /root/.ssh/authorized_keys
 
 %post --interpreter /bin/bash --log /root/ks-post.log.2
 
-{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 # Add mellanox ethernet modules to autoload on boot. This way, if a host has a
 # mellanox card, it will come up in the ethernet mode.
 echo mlx4_en >>/etc/modules-load.d/mlx4.conf

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -1,6 +1,11 @@
 install
 text
+reboot
+skipx
+
+{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
 network --noipv6
+{% endif %}
 
 # The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
 # Ansible has no way of accessing a group's variables, so they are accessed
@@ -22,15 +27,27 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 bootloader --location=mbr --append elevator=deadline
+{% endif %}
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+bootloader --location=mbr --append="rhgb quiet crashkernel=auto"
+{% endif %}
+
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
+
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 selinux --disabled
-reboot
 firewall --service=ssh
-skipx
 services --enabled=ntpd
+{% endif %}
+
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+selinux --permissive
+firewall --enabled --ssh
+{% endif %}
 
 {% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}
 logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
@@ -44,6 +61,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endfor %}
 
 %packages
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 {% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
 @ Base
 -NetworkManager
@@ -58,6 +76,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {% endif %}
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
+{% endif %}
 {% endif %}
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
@@ -83,6 +102,8 @@ chmod 600 /root/.ssh/authorized_keys
 %end
 
 %post --interpreter /bin/bash --log /root/ks-post.log.2
+
+{% if [groups[item][0]]['dhcp_kickstart_centos_version'] is "7" %}
 # Add mellanox ethernet modules to autoload on boot. This way, if a host has a
 # mellanox card, it will come up in the ethernet mode.
 echo mlx4_en >>/etc/modules-load.d/mlx4.conf
@@ -95,10 +116,13 @@ modprobe bonding
 #Disable NetworkManger service
 systemctl stop NetworkManager
 systemctl disable NetworkManager
+{% endif %}
 
+{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
 # Disable Ipv6 at the kernel level
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+{%endif %}
 
 {% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
 ####### Extra POST commands

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -50,7 +50,7 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] == '8' %}
 bootloader --location=mbr --append="rhgb quiet crashkernel=auto"
 {% else %}
 # Default to CentOS 7
@@ -61,7 +61,7 @@ timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/He
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] == '8' %}
 selinux --permissive
 firewall --enabled --ssh
 {% else %}
@@ -88,7 +88,7 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}
 # If CentOS8 is set in the group, we do a...
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] == '8' %}
 # ...no-op.
 # For consideration: Might this be a good spot for @Core?
 {% else %}
@@ -133,7 +133,7 @@ chmod 600 /root/.ssh/authorized_keys
 
 %post --interpreter /bin/bash --log /root/ks-post.log.2
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is "8" %}
+{% if hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_centos_version'] == '8' %}
 # No-op.
 {% else %}
 # Add mellanox ethernet modules to autoload on boot. This way, if a host has a

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -17,8 +17,19 @@ skipx
 # fallback to the value of 'variable' from role defaults/main.yml.
 # Source: https://github.com/ansible/ansible/issues/6189
 
-{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
+# A comprehensive variable lookup navigating this rather perplexing template
+# would consist of the following:
+
+# 1) First check if the variable is defined in the hostvars, and of desired value
+{% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is sameas true %}
 network --noipv6
+# 2) Then check any other desired values for the same
+{% elif hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is defined and hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is sameas false %}
+network
+# 3) If it wasn't defined in hostvars, we can still have a separate lookup into the role defaults for a particular value
+{% elif dhcp_kickstart_disable_ipv6 is sameas true %}
+network --noipv6
+# 4) If role default turned out to be of undesired value as well, fall back to some kind of default action.
 {% else %}
 network
 {% endif %}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -7,6 +7,16 @@ skipx
 # Ansible has no way of accessing a group's variables, so they are accessed
 # via the first host of the group.
 
+# As per commit 9b0e011f, variables should be
+# "set for the group, so for example group_vars/groupname/vars.yml
+# it's not enough to specify them in group_vars/all.yml
+# because of how we use hostvars[] to write the kickstart templates."
+
+# This also means that role defaults will not end up in hostvars.
+# You can't refer to hostvars[groups[item][0]]['variable'] and expect it to
+# fallback to the value of 'variable' from role defaults/main.yml.
+# Source: https://github.com/ansible/ansible/issues/6189
+
 {% if hostvars[groups[item][0]]['dhcp_kickstart_disable_ipv6'] is True %}
 network --noipv6
 {% else %}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -96,10 +96,12 @@ ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 -NetworkManager-team
 -NetworkManager-wwan
 {% endif %}
+# As an exception, this variable is not read from hostvars.
 {% if dhcp_kickstart_install_chrony == false %}
 -chrony
 {% endif %}
 {% endif %}
+# Always install these packages when defined.
 {% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
 {{ hostvars[groups[item][0]]['kickstart_packages'] }}
 {% endif %}

--- a/tests/group_vars/compute3/vars.yml
+++ b/tests/group_vars/compute3/vars.yml
@@ -6,7 +6,6 @@ serialport: "console=ttyS1,115200"
 kernel_numa_param: "off"
 dhcp_kickstart_manage_packages: "anything"
 kickstart_packages: |
-  %packages --nobase
   @core
   vim-enhanced
   openssh-clients


### PR DESCRIPTION
- More comprehensive documentation preamble in kickstart.j2 on how
you can and can *not* use variable lookup in that template
- Remove role defaults which do not apply to kickstart.j2 so that they
won't give the illusion of being in effect
- Check more places for variables impacting IPv6 disable feature
- Reorganize most things so that we first do a CentOS8 specific
lookup and then fall back to CentOS7 behavior
- Add more comments for %packages section.
- Adjust tests to accommodate for changes in %packages.