### PR TITLE
Sexprs #859 enable 8stream configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Mandatory:
  - kernel_url_path (path where kickstart kernel and initrd can be found)
 
 Optional:
+ - bootloader_append (extra kernel parameters)
  - serialport (for during kickstart)
  - extra_kernel_params (for during kickstart)
  - dhcp_domain

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Mandatory:
  - root_keys (public ssh keys to deploy for root)
 
 Optional:
- - kernel_numa_param(can be set to off)
+ - kernel_numa_param (can be set to off)
+ - selinux_setting (sets the state of SELinux on the installed system [--disabled|--enforcing|--permissive])
 
 Touch a file to start a reinstall
 ----------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,9 +93,8 @@
   when: |
     item not in dhcp_kickstart_skip_these_groups and
     groups[item][0] is defined and
-    hostvars[groups[item][0]]['os_disks'] is defined and
-    ansible_os_family == "RedHat" and
-    ansible_distribution_major_version <= "7"
+    hostvars[groups[item][0]]['os_disks'] is defined and 
+    target_centos_major_version is undefined
 
 - name: create_kickstart_group_files for Centos 8-stream nodes
   template: src=kickstart_stream8.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
@@ -104,9 +103,8 @@
   when: |
     item not in dhcp_kickstart_skip_these_groups and
     groups[item][0] is defined and
-    hostvars[groups[item][0]]['os_disks'] is defined and
-    ansible_os_family == 'RedHat' and
-    ansible_distribution_major_version == "8"
+    hostvars[groups[item][0]]['os_disks'] is defined 
+#    and target_centos_major_version == 8
 
 - name: copy memtest.0 PXE NBP
   copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,14 +86,27 @@
   template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json' backup=yes
   tags: pxe_data
 
-- name: create_kickstart_group_files
+- name: create_kickstart_group_files for legacy nodes
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
-  when:
-    - item not in dhcp_kickstart_skip_these_groups
-    - groups[item][0] is defined
-    - hostvars[groups[item][0]]['os_disks'] is defined
+  when: |
+    item not in dhcp_kickstart_skip_these_groups and
+    groups[item][0] is defined and
+    hostvars[groups[item][0]]['os_disks'] is defined and
+    ansible_os_family == "RedHat" and
+    ansible_distribution_major_version <= "7"
+
+- name: create_kickstart_group_files for Centos 8-stream nodes
+  template: src=kickstart_stream8.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
+  tags: dhcp_kickstart_config
+  with_items: "{{ groups|sort }}"
+  when: |
+    item not in dhcp_kickstart_skip_these_groups and
+    groups[item][0] is defined and
+    hostvars[groups[item][0]]['os_disks'] is defined and
+    ansible_os_family == 'RedHat' and
+    ansible_distribution_major_version == "8"
 
 - name: copy memtest.0 PXE NBP
   copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -22,7 +22,7 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
-bootloader --location=mbr --append elevator=deadline
+bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('elevator=deadline') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
 auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -7,9 +7,9 @@ network --noipv6
 # via the first host of the group.
 
 {% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
-url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
 {% else %}
-url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }}
 {% endif %}
 
 {% for repo in hostvars[groups[item][0]]['additional_repos'] %}
@@ -24,10 +24,8 @@ keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1
 zerombr
 bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('elevator=deadline') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
-# Comment out line with command "auth" for Centos 8-Stream/RHEL8 installations, as it is deprecated.
 auth --enableshadow --passalgo=sha512
-# Uncomment line containing "authselect" for Centos 8-Stream/RHEL 8 installations, as auth is deprecated.
-# authselect --enableshadow --passalgo=sha512
+
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('disabled') }}
 reboot
@@ -39,7 +37,7 @@ services --enabled=ntpd
 logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
 {% endif %}
 
-clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
+clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
 ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 
 {% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -24,7 +24,10 @@ keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1
 zerombr
 bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('elevator=deadline') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
+# Comment out line with command "auth" for Centos 8-Stream/RHEL8 installations, as it is deprecated.
 auth --enableshadow --passalgo=sha512
+# Uncomment line containing "authselect" for Centos 8-Stream/RHEL 8 installations, as auth is deprecated.
+# authselect --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --disabled
 reboot

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -31,7 +31,7 @@ auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('disabled') }}
 reboot
-firewall --service=ssh
+firewall --enabled --ssh
 skipx
 services --enabled=ntpd
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -29,7 +29,7 @@ auth --enableshadow --passalgo=sha512
 # Uncomment line containing "authselect" for Centos 8-Stream/RHEL 8 installations, as auth is deprecated.
 # authselect --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
-selinux --disabled
+selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('disabled') }}
 reboot
 firewall --service=ssh
 skipx

--- a/templates/kickstart_stream8.j2
+++ b/templates/kickstart_stream8.j2
@@ -1,0 +1,86 @@
+install
+text
+network --noipv6
+
+# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
+# Ansible has no way of accessing a group's variables, so they are accessed
+# via the first host of the group.
+
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+{% endif %}
+
+{% for repo in hostvars[groups[item][0]]['additional_repos'] %}
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+repo --name={{ repo.name }} --baseurl={{ repo.url }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
+repo --name={{ repo.name }} --baseurl={{ repo.url }}
+{% endif %}
+{% endfor %}
+lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
+keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
+zerombr
+bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('rhgb quiet crashkernel=auto') }}
+timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
+authselect --enableshadow --passalgo=sha512
+rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
+selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('enforcing') }}
+reboot
+firewall --enabled --ssh
+skipx
+
+{% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}
+logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
+{% endif %}
+
+clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
+ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
+
+{% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}
+{{ line }}
+{% endfor %}
+
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
+%end
+
+{% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}
+{% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined %}
+####### Extra PRE commands
+{{ hostvars[groups[item][0]]['kickstart_pre_option'] }}
+{{ hostvars[groups[item][0]]['kickstart_extra_pre_commands'] }}
+%end
+{% endif %}
+{% endif %}
+
+%post --interpreter /bin/bash --log /root/ks-post.log.1
+mkdir -p /root/.ssh
+{% for key in hostvars[groups[item][0]]['root_keys'] %}
+echo "{{ key }}" >> /root/.ssh/authorized_keys
+{% endfor %}
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+%end
+
+# Disable Ipv6 at the kernel level
+echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+
+{% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
+####### Extra POST commands
+{{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}
+{% endif %}
+
+{% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}" --remove-args="{{ hostvars[groups[item][0]]['kickstart_grubby_remove_args'] }}"
+{% elif hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is not defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}"
+{% else %}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}"
+{% endif %}
+# End post install kernel options update
+%end
+

--- a/templates/kickstart_stream8.j2
+++ b/templates/kickstart_stream8.j2
@@ -1,4 +1,3 @@
-install
 text
 network --noipv6
 
@@ -24,7 +23,7 @@ keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1
 zerombr
 bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('rhgb quiet crashkernel=auto') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
-authselect --enableshadow --passalgo=sha512
+auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('enforcing') }}
 reboot


### PR DESCRIPTION
Role updated to use separate jinja template for Centos 8-stream nodes for creating kickstart files.

In addition, older Centos 7 compatible jinja template was modied to accept configurations from "bootloader --append" flag.
Configuring selinux was made possible in Centos 7 kickstarts, as "selinux_setting" variable can now be defined and it is delivered as a flag.