### PR TITLE
Sexprs #859 enable 8stream configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Mandatory:
  - kernel_url_path (path where kickstart kernel and initrd can be found)
 
 Optional:
+ - bootloader_append (extra kernel parameters)
  - serialport (for during kickstart)
  - extra_kernel_params (for during kickstart)
  - dhcp_domain
@@ -78,7 +79,8 @@ Mandatory:
  - root_keys (public ssh keys to deploy for root)
 
 Optional:
- - kernel_numa_param(can be set to off)
+ - kernel_numa_param (can be set to off)
+ - selinux_setting (sets the state of SELinux on the installed system [--disabled|--enforcing|--permissive])
 
 Touch a file to start a reinstall
 ----------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json' backup=yes
   tags: pxe_data
 
-- name: create_kickstart_group_files
+- name: create_kickstart_group_files for legacy nodes
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
@@ -94,6 +94,17 @@
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
+    - hostvars[groups[item][0]]['target_os_centos_8stream'] is undefined
+
+- name: create_kickstart_group_files for Centos 8-stream nodes
+  template: src=kickstart_stream8.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
+  tags: dhcp_kickstart_config
+  with_items: "{{ groups|sort }}"
+  when:
+    - item not in dhcp_kickstart_skip_these_groups
+    - groups[item][0] is defined
+    - hostvars[groups[item][0]]['os_disks'] is defined
+    - hostvars[groups[item][0]]['target_os_centos_8stream'] is defined
 
 - name: copy memtest.0 PXE NBP
   copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
-    - hostvars[groups[item][0]]['target_os_centos_8stream'] is undefined
+    - hostvars[groups[item][0]]['target_os'] is undefined
 
 - name: create_kickstart_group_files for Centos 8-stream nodes
   template: src=kickstart_stream8.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
@@ -104,7 +104,8 @@
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
-    - hostvars[groups[item][0]]['target_os_centos_8stream'] is defined
+    - hostvars[groups[item][0]]['target_os'] is defined
+    - hostvars[groups[item][0]]['target_os'] == "centos_8stream"
 
 - name: copy memtest.0 PXE NBP
   copy: src=memtest.0 dest=/var/www/html/memtest.0 owner=apache group=apache mode="0440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Fail if 'target_os' variable is unknown
+  fail:
+    msg: "target_os variable in the host group {{ item }} is unknown. Only values centos7 or centos_8stream are accepted."
+  with_items: "{{ groups|sort }}"
+  when:
+    - item not in dhcp_kickstart_skip_these_groups
+    - groups[item][0] is defined
+    - hostvars[groups[item][0]]['target_os'] is defined
+    - hostvars[groups[item][0]]['target_os'] != "centos7"
+    - hostvars[groups[item][0]]['target_os'] != "centos_8stream"
+
 - name: install_apache_httpd
   yum: name='httpd' state='present'
 
@@ -90,11 +101,11 @@
   template: src=kickstart.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes
   tags: dhcp_kickstart_config
   with_items: "{{ groups|sort }}"
-  when:
+  when: 
     - item not in dhcp_kickstart_skip_these_groups
     - groups[item][0] is defined
     - hostvars[groups[item][0]]['os_disks'] is defined
-    - hostvars[groups[item][0]]['target_os'] is undefined
+    - hostvars[groups[item][0]]['target_os'] is undefined or hostvars[groups[item][0]]['target_os'] == "centos7"
 
 - name: create_kickstart_group_files for Centos 8-stream nodes
   template: src=kickstart_stream8.j2 dest="/var/www/html/kickstart/{{item}}.ks" validate='/usr/bin/ksvalidator %s' backup=yes

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -7,9 +7,9 @@ network --noipv6
 # via the first host of the group.
 
 {% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
-url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
 {% else %}
-url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }}
 {% endif %}
 
 {% for repo in hostvars[groups[item][0]]['additional_repos'] %}
@@ -22,13 +22,14 @@ repo --name={{ repo.name }} --baseurl={{ repo.url }}
 lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
 keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
 zerombr
-bootloader --location=mbr --append elevator=deadline
+bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('elevator=deadline') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
 auth --enableshadow --passalgo=sha512
+
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
-selinux --disabled
+selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('disabled') }}
 reboot
-firewall --service=ssh
+firewall --enabled --ssh
 skipx
 services --enabled=ntpd
 
@@ -36,7 +37,7 @@ services --enabled=ntpd
 logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
 {% endif %}
 
-clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
+clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
 ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
 
 {% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}

--- a/templates/kickstart_stream8.j2
+++ b/templates/kickstart_stream8.j2
@@ -1,0 +1,111 @@
+text
+network --noipv6
+
+# The hostvars[groups[item][0]]['install_repo'] pattern is used in this template
+# Ansible has no way of accessing a group's variables, so they are accessed
+# via the first host of the group.
+
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
+url --url {{ hostvars[groups[item][0]]['install_repo'] }}
+{% endif %}
+
+{% for repo in hostvars[groups[item][0]]['additional_repos'] %}
+{% if hostvars[groups[item][0]]['yum_proxy'] is defined %}
+repo --name={{ repo.name }} --baseurl={{ repo.url }} --proxy={{ hostvars[groups[item][0]]['yum_proxy'] }}
+{% else %}
+repo --name={{ repo.name }} --baseurl={{ repo.url }}
+{% endif %}
+{% endfor %}
+lang {{ hostvars[groups[item][0]]['kickstart_lang'] | default('en_US.UTF-8') }}
+keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1') }}
+zerombr
+bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('rhgb quiet crashkernel=auto') }}
+timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
+auth --enableshadow --passalgo=sha512
+rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
+selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('enforcing') }}
+reboot
+firewall --enabled --ssh
+skipx
+
+{% if hostvars[groups[item][0]]['kickstart_log_host'] is defined %}
+logging --host={{ hostvars[groups[item][0]]['kickstart_log_host'] }}
+{% endif %}
+
+clearpart --all --drives={{ hostvars[groups[item][0]]['os_disks'] }} --initlabel
+ignoredisk --only-use={{ hostvars[groups[item][0]]['os_disks'] }}
+
+{% for line in hostvars[groups[item][0]]['kickstart_partitions'] %}
+{{ line }}
+{% endfor %}
+
+
+{% if hostvars[groups[item][0]]['dhcp_kickstart_manage_packages'] is not defined %}
+%packages
+@ Base
+-alsa-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+python3
+{% endif %}
+
+{% if hostvars[groups[item][0]]['kickstart_packages'] is defined %}
+{{ hostvars[groups[item][0]]['kickstart_packages'] }}
+{% endif %}
+%end
+
+{% if hostvars[groups[item][0]]['kickstart_pre_option'] is defined %}
+{% if hostvars[groups[item][0]]['kickstart_extra_pre_commands'] is defined %}
+####### Extra PRE commands
+{{ hostvars[groups[item][0]]['kickstart_pre_option'] }}
+{{ hostvars[groups[item][0]]['kickstart_extra_pre_commands'] }}
+%end
+{% endif %}
+{% endif %}
+
+%post --interpreter /bin/bash --log /root/ks-post.log.1
+mkdir -p /root/.ssh
+{% for key in hostvars[groups[item][0]]['root_keys'] %}
+echo "{{ key }}" >> /root/.ssh/authorized_keys
+{% endfor %}
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+%end
+
+%post --interpreter /bin/bash --log /root/ks-post.log.2
+
+# Disable Ipv6 at the kernel level
+echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+
+{% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
+####### Extra POST commands
+{{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}
+{% endif %}
+
+{% if hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}" --remove-args="{{ hostvars[groups[item][0]]['kickstart_grubby_remove_args'] }}"
+{% elif hostvars[groups[item][0]]['kickstart_grubby_remove_args'] is not defined and hostvars[groups[item][0]]['kickstart_grubby_args'] is defined%}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ hostvars[groups[item][0]]['kickstart_grubby_args'] }}"
+{% else %}
+/sbin/grubby --update-kernel=`/sbin/grubby --default-kernel` --args="{{ kickstart_grubby_args }}"
+{% endif %}
+# End post install kernel options update
+%end
+

--- a/tests/group_vars/8-stream/vars.yml
+++ b/tests/group_vars/8-stream/vars.yml
@@ -2,5 +2,5 @@ kickstart_url: "http:///{{ dhcp_server_ip }}/8-stream-nodes.ks"
 kernel_url_path: "http://www.nic.funet.fi/pub/mirrors/centos.org/8-stream/BaseOS/x86_64/os/isolinux/"
 install_repo: "https://www.nic.funet.fi/pub/mirrors/centos.org/8-stream/BaseOS/x86_64/os/"
 additional_repos: ""
-target_os_centos_8stream: True
+target_os: "centos_8stream"
 os_disks: "/dev/disk/by-path/pci-0000:00:17.0-ata-1"

--- a/tests/group_vars/8-stream/vars.yml
+++ b/tests/group_vars/8-stream/vars.yml
@@ -1,0 +1,6 @@
+kickstart_url: "http:///{{ dhcp_server_ip }}/8-stream-nodes.ks"
+kernel_url_path: "http://www.nic.funet.fi/pub/mirrors/centos.org/8-stream/BaseOS/x86_64/os/isolinux/"
+install_repo: "https://www.nic.funet.fi/pub/mirrors/centos.org/8-stream/BaseOS/x86_64/os/"
+additional_repos: ""
+target_os_centos_8stream: True
+os_disks: "/dev/disk/by-path/pci-0000:00:17.0-ata-1"

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -22,3 +22,4 @@ kickstart_partitions:
 root_keys:
  - "ssh-rsa key"
  - "ssh-rsa key2"
+...

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -22,4 +22,3 @@ kickstart_partitions:
 root_keys:
  - "ssh-rsa key"
  - "ssh-rsa key2"
-...

--- a/tests/group_vars/compute1/vars.yml
+++ b/tests/group_vars/compute1/vars.yml
@@ -3,4 +3,4 @@ ip_address: '127.0.1.1'
 mac_address: "00:00:00:00:aa:c1"
 os_disks: "sda"
 extra_kernel_params: "blacklist=megaraid"
-
+...

--- a/tests/group_vars/compute1/vars.yml
+++ b/tests/group_vars/compute1/vars.yml
@@ -1,7 +1,6 @@
 ---
-
 ip_address: '127.0.1.1'
 mac_address: "00:00:00:00:aa:c1"
 os_disks: "sda"
 extra_kernel_params: "blacklist=megaraid"
-...
+

--- a/tests/inventory
+++ b/tests/inventory
@@ -14,9 +14,13 @@ installnode
 [compute1]
 computenode1
 computenode11
+
 [compute2]
 computenode2
 computenode22
+
+[8-stream]
+8-streamnode
 
 [dhcp_pxe_hosts:children]
 pxe_bootable_nodes
@@ -44,3 +48,4 @@ compute3
 [compute3]
 computenode3
 computenode33
+


### PR DESCRIPTION
Role updated to use separate jinja template for Centos 8-stream nodes for creating kickstart files.

In addition, older Centos 7 compatible jinja template was modied to accept configurations from "bootloader --append" flag.
Configuring selinux was made possible in Centos 7 kickstarts, as "selinux_setting" variable can now be defined and it is delivered as a flag.


