### PR TITLE
remove legacy auth paremeter from centos-8stream installations

### DIFF
--- a/templates/kickstart_stream8.j2
+++ b/templates/kickstart_stream8.j2
@@ -23,7 +23,6 @@ keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1
 zerombr
 bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('rhgb quiet crashkernel=auto') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
-auth --enableshadow --passalgo=sha512
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('enforcing') }}
 reboot


### PR DESCRIPTION
"auth" parater is deprecated in centos-8stream and is replaced with authselect.



Quote from authselect-migration - Man Page https://www.mankier.com/7/authselect-migration#)]https://www.mankier.com/7/authselect-migration

> Authconfig options --enableshadow and --passalgo=sha512 were often used to make sure that passwords are stored in /etc/shadow using sha512 algorithm. The authselect profiles now use the yescrypt hashing method and it cannot be changed through an option (only by creating a custom profile). You can just omit these options.

We will remove "auth" as it does not provide usable parameter for centos-8stream.