### PR TITLE
do not disable ipv6 by default at 8-stream nodes

### DIFF
--- a/templates/kickstart_stream8.j2
+++ b/templates/kickstart_stream8.j2
@@ -89,10 +89,6 @@ chmod 600 /root/.ssh/authorized_keys
 
 %post --interpreter /bin/bash --log /root/ks-post.log.2
 
-# Disable Ipv6 at the kernel level
-echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
-echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
-
 {% if hostvars[groups[item][0]]['kickstart_extra_post_commands'] is defined %}
 ####### Extra POST commands
 {{ hostvars[groups[item][0]]['kickstart_extra_post_commands'] }}


### PR DESCRIPTION
This fix addresses to a issue where sysctl tries to call entries at /etc/sysctl.conf, but corresponding files at /proc/sys/net/ipv6 do not exist, because ipv6 has been disabled with grubby args in kickstart.

```

[root@helloworld /boot/grub2]# sysctl -p
sysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory
sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory`

```
Also, we probably can't expect that all installations should have ipv6 disabled by default. If we  want, we use define grubby_args variabe at ansible with value "ipv6.disable=1", which will do the same.