### PR TITLE
Place dhcpv6 related kickstart file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 hosts_file_pxe_group_to_populate: "{{ groups.dhcp_pxe_hosts }}"
 
 dhcp_group: "dhcp_only_hosts"
+dhcp6_group: "dhcp6_only_hosts"
 dhcp_pxe_group: "dhcp_pxe_hosts"
 dhcp_kickstart_install_chrony: False
 dhcp_kickstart_handle_dhcpd: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,7 @@
 - name: restart dhcpd-kickstart
   service: name=dhcpd state=restarted
   when: dhcp_kickstart_handle_dhcpd
+
+- name: restart dhcpd6-kickstart
+  service: name=dhcpd6 state=restarted
+  when: dhcp_kickstart_handle_dhcpd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,13 @@
   notify:
     - restart dhcpd-kickstart
 
+- name: create_dhcp6_config
+  template: src=dhcp_nodes6.conf dest="/etc/dhcp/dhcpd.d/dhcp_nodes6.conf"
+  when: groups[dhcp6_group] is defined
+  tags: dhcp6_config
+  notify:
+    - restart dhcpd6-kickstart
+
 - name: create_dhcp_ipxe_configs
   template: src=dhcp_pxe_nodes.conf dest="/etc/dhcp/dhcpd.d/dhcp_pxe_nodes.conf"
   when: groups[dhcp_pxe_group] is defined

--- a/templates/dhcp_nodes6.conf
+++ b/templates/dhcp_nodes6.conf
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+{% for item in groups[dhcp6_group]|sort %}
+host {{ item }} {
+  hardware ethernet {{ hostvars[item]['mac_address'] }};
+  host-identifier option dhcp-client-identifier {{ hostvars[item]['mac_address'] }};
+  fixed-address6 {{ hostvars[item]['ip_address'] }};
+}
+{% endfor %}


### PR DESCRIPTION
This change will place dhcp_nodes6.conf file to /etc/dhcp/dhcpd.d/dhcp_nodes6.conf.
This file will contain individual IPv6 address corresponding to a specific nodes matching
with its Mac address.