### PR TITLE
Make "network --noipv6" instruction parametric

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Optional:
  - kickstart_extra_pre_option
  - kickstart_extra_pre_commands
  - kickstart_extra_post_commands
+ - kickstart_network_options (e.g. to explicitly disable IPv6 in the kickstarted operating system)
 
 The nodes which only need to be set up for DHCP need to be in the
 (by default) "dhcp_only_nodes"  group. These nodes need the following 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+kickstart_network_options: "network --noipv6"
+
 hosts_file_pxe_group_to_populate: "{{ groups.dhcp_pxe_hosts }}"
 
 dhcp_group: "dhcp_only_hosts"

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -1,7 +1,5 @@
 text
-{% if (hostvars[groups[item][0]]['network_noipv6'] is not defined) or (hostvars[groups[item][0]]['network_noipv6']) %}
-network --noipv6
-{% endif %}
+{{ hostvars[groups[item][0]]['kickstart_network_options'] }}
 
 firstboot --disable
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -1,5 +1,7 @@
 text
+{% if (hostvars[groups[item][0]]['network_noipv6'] is not defined) or (hostvars[groups[item][0]]['network_noipv6']) %}
 network --noipv6
+{% endif %}
 
 firstboot --disable
 

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -1,5 +1,5 @@
 text
-{{ hostvars[groups[item][0]]['kickstart_network_options'] }}
+{{ hostvars[groups[item][0]]['kickstart_network_options'] | default(kickstart_network_options) }}
 
 firstboot --disable
 


### PR DESCRIPTION
We want to offer the option of keeping ipv6 module enabled after the kickstarting. This commit will normally write the instruction to disable ipv6, unless the variable "network_noipv6" is defined and explicitly set to false.