### PR TITLE
Remove deprecated commands

### DIFF
--- a/templates/kickstart_legacy.j2
+++ b/templates/kickstart_legacy.j2
@@ -1,4 +1,3 @@
-install
 text
 network --noipv6
 
@@ -24,7 +23,6 @@ keyboard {{ hostvars[groups[item][0]]['kickstart_keyboard'] | default('fi-latin1
 zerombr
 bootloader --location=mbr --append {{ hostvars[groups[item][0]]['bootloader_append'] | default('elevator=deadline') }}
 timezone {{ hostvars[groups[item][0]]['kickstart_timezone'] | default('Europe/Helsinki') }}
-auth --enableshadow --passalgo=sha512
 
 rootpw --iscrypted {{ hostvars[groups[item][0]]['root_password_hash'] }}
 selinux --{{ hostvars[groups[item][0]]['selinux_setting'] | default('disabled') }}


### PR DESCRIPTION
"install" and "auth" / "authconfig" commands are deprecated in RHEL8 and removed in RHEL9.

"install" is redundant, since the "url" command is sufficient for the purpose of specifying the installation media

"auth" is technically replaced by "authselect", but the following can be found from authselect-migration manual:
```
Note
Authconfig options --enableshadow and --passalgo=sha512 were often used to make sure that passwords are stored in /etc/shadow using sha512 algorithm. The authselect profiles now use the sha512 hashing method and it cannot be changed through an option (only by creating a custom profile). You can just omit these options.
```